### PR TITLE
Remove now-go from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ A collection of awesome things regarding ZEIT's [Micro](https://github.com/zeit/
 ## Built with Micro
 
 - [Serve](https://github.com/zeit/serve) - Static file serving and directory listing
-- [now-go](https://github.com/amio/now-go) - A personal tinyurl service
 - [micro-github](https://github.com/mxstbr/micro-github) - Add authentication with GitHub to your application
 - [micro-figma](https://github.com/jongold/micro-figma) - Add authentication with Figma to your application
 - [marked](https://github.com/amio/marked) - Markdown render service


### PR DESCRIPTION
now-go is not using micro since https://github.com/amio/now-go/commit/84cc8e6e2854a8e4248334fb55b288e5ea826eae