### PR TITLE
Add micro-helmet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A collection of awesome things regarding ZEIT's [Micro](https://github.com/zeit/
 - [micronize](https://github.com/nickcis/micronize) - Simple way of enhacing a function with Zeit's Micro framework (usefull for serverless environment, ie: now & aws lambda).
 - [micro-morgan](https://github.com/nickcis/micro-morgan) - [Morgan](https://github.com/expressjs/morgan) HTTP request logger middleware for Zeit's Micro framework.
 - [serve-handler](https://github.com/zeit/serve-handler) - Static file serving and directory listing handler, used by [Serve](https://github.com/zeit/serve)
+- [micro-helmet](https://github.com/goto-bus-stop/micro-helmet) - Security headers for micro, using the popular [Helmet](https://www.npmjs.com/package/helmet) module
 
 ## Deployment Tools
 - [aws-serverless-micro](https://github.com/nathancahill/aws-serverless-micro) - Deploy Micro functions on AWS Lambda


### PR DESCRIPTION
A wrapper around helmet that hides the express middleware API behind something that fits in better with micro :v: